### PR TITLE
T0003 & T0004 test parameter order values for getFollowerList()

### DIFF
--- a/src/main/java/com/bootcamp/be_java_hisp_w25_g02/controller/UserController.java
+++ b/src/main/java/com/bootcamp/be_java_hisp_w25_g02/controller/UserController.java
@@ -42,6 +42,7 @@ public class UserController {
     }
 
     @GetMapping("/user/{userId}/followers")
+    // Ojo -- Originalmente habiamos escrito @RequestParam(required = false) para String order, pero por la User Story, parece obligatorio.
     public ResponseEntity<?> getFollowersList(@PathVariable @Positive Integer userId, @RequestParam(required = false) String order){
         FollowerListDTO followersList = userService.getFollowersList(userId, order);
         return new ResponseEntity<>(followersList, HttpStatus.OK);

--- a/src/main/java/com/bootcamp/be_java_hisp_w25_g02/controller/UserController.java
+++ b/src/main/java/com/bootcamp/be_java_hisp_w25_g02/controller/UserController.java
@@ -42,7 +42,6 @@ public class UserController {
     }
 
     @GetMapping("/user/{userId}/followers")
-    // Ojo -- Originalmente habiamos escrito @RequestParam(required = false) para String order, pero por la User Story, parece obligatorio.
     public ResponseEntity<?> getFollowersList(@PathVariable @Positive Integer userId, @RequestParam(required = false) String order){
         FollowerListDTO followersList = userService.getFollowersList(userId, order);
         return new ResponseEntity<>(followersList, HttpStatus.OK);

--- a/src/main/java/com/bootcamp/be_java_hisp_w25_g02/service/UserServiceImpl.java
+++ b/src/main/java/com/bootcamp/be_java_hisp_w25_g02/service/UserServiceImpl.java
@@ -123,11 +123,10 @@ public class UserServiceImpl implements IUserService{
     public FollowerListDTO getFollowersList(Integer userId, String order) {
 
         // Excepciones en caso de que el parámetro no coincida (ignorecase) con "name_asc" o "name_desc"
-        if (!order.equalsIgnoreCase("name_asc") && !order.equalsIgnoreCase("name_desc")){
+        if (order != null && !order.equalsIgnoreCase("name_asc") && !order.equalsIgnoreCase("name_desc")){
             throw new BadRequestException("El valor de ordenamiento '" + order + "' no es válido. Los valores permitidos son: 'name_asc' y 'name_desc'.");
         }
         Optional<User> user = userRepository.findById(userId);
-        System.out.println("lestoy acá");
         if (user.isEmpty()) throw new NotFoundException("No hay usuario asociado a esa ID");
         if (!user.get().getSeller()) throw new BadRequestException("Este usuario no es vendedor, no puede poseer seguidores.");
         List<Integer> followersIdList = user.get().getFollowedBy();
@@ -137,11 +136,13 @@ public class UserServiceImpl implements IUserService{
 
         // Aquí lógica de ordenamiento
         // Lógica de ordenamiento asc y desc.
-        if (order.equalsIgnoreCase("name_asc")){
-            followersList = followersList.stream().sorted(Comparator.comparing(UserDTO::userName)).toList();
-        }
-        if (order.equalsIgnoreCase("name_desc")){
-            followersList = followersList.stream().sorted(Comparator.comparing(UserDTO::userName).reversed()).toList();
+        if (order != null) {
+            if (order.equalsIgnoreCase("name_asc")){
+                followersList = followersList.stream().sorted(Comparator.comparing(UserDTO::userName)).toList();
+            }
+            if (order.equalsIgnoreCase("name_desc")){
+                followersList = followersList.stream().sorted(Comparator.comparing(UserDTO::userName).reversed()).toList();
+            }
         }
         FollowerListDTO ansDTO = new FollowerListDTO(userId, user.get().getUserName(), followersList);
         return ansDTO;

--- a/src/main/java/com/bootcamp/be_java_hisp_w25_g02/service/UserServiceImpl.java
+++ b/src/main/java/com/bootcamp/be_java_hisp_w25_g02/service/UserServiceImpl.java
@@ -121,18 +121,26 @@ public class UserServiceImpl implements IUserService{
 
     @Override
     public FollowerListDTO getFollowersList(Integer userId, String order) {
+
+        // Excepciones en caso de que el parámetro no coincida (ignorecase) con "name_asc" o "name_desc"
+        if (!order.equalsIgnoreCase("name_asc") && !order.equalsIgnoreCase("name_desc")){
+            throw new BadRequestException("El valor de ordenamiento '" + order + "' no es válido. Los valores permitidos son: 'name_asc' y 'name_desc'.");
+        }
         Optional<User> user = userRepository.findById(userId);
+        System.out.println("lestoy acá");
         if (user.isEmpty()) throw new NotFoundException("No hay usuario asociado a esa ID");
         if (!user.get().getSeller()) throw new BadRequestException("Este usuario no es vendedor, no puede poseer seguidores.");
         List<Integer> followersIdList = user.get().getFollowedBy();
         if (followersIdList.isEmpty()) throw new NotFoundException("El usuario no posee seguidores");
         List<UserDTO> followersList = followersIdList.stream().map(userRepository::findById)
                 .map(userA -> new UserDTO(userA.get().getUserId(), userA.get().getUserName())).toList();
-        // Aquí lógica de ordenamiento si hay orden
-        if (order != null && order.equalsIgnoreCase("name_asc")){
+
+        // Aquí lógica de ordenamiento
+        // Lógica de ordenamiento asc y desc.
+        if (order.equalsIgnoreCase("name_asc")){
             followersList = followersList.stream().sorted(Comparator.comparing(UserDTO::userName)).toList();
         }
-        if (order != null && order.equalsIgnoreCase("name_desc")){
+        if (order.equalsIgnoreCase("name_desc")){
             followersList = followersList.stream().sorted(Comparator.comparing(UserDTO::userName).reversed()).toList();
         }
         FollowerListDTO ansDTO = new FollowerListDTO(userId, user.get().getUserName(), followersList);

--- a/src/test/java/com/bootcamp/be_java_hisp_w25_g02/controller/UserControllerTest.java
+++ b/src/test/java/com/bootcamp/be_java_hisp_w25_g02/controller/UserControllerTest.java
@@ -4,14 +4,32 @@ import com.bootcamp.be_java_hisp_w25_g02.service.IUserService;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.bootcamp.be_java_hisp_w25_g02.repository.IUserRepository;
+import com.bootcamp.be_java_hisp_w25_g02.service.UserServiceImpl;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.jupiter.api.Assertions.*;
+
 @ExtendWith(MockitoExtension.class)
+@SpringBootTest
+
 class UserControllerTest {
     @Mock
     IUserService userService;
     @Mock
     UserController userController;
 
+
+    @Mock
+    IUserRepository iUserRepository;
+
+    @InjectMocks
+    UserServiceImpl userServiceImpl;
 
 }

--- a/src/test/java/com/bootcamp/be_java_hisp_w25_g02/service/UserServiceImplTest.java
+++ b/src/test/java/com/bootcamp/be_java_hisp_w25_g02/service/UserServiceImplTest.java
@@ -1,17 +1,92 @@
 package com.bootcamp.be_java_hisp_w25_g02.service;
 
 import com.bootcamp.be_java_hisp_w25_g02.repository.IUserRepository;
+import com.bootcamp.be_java_hisp_w25_g02.dto.response.UserDTO;
+import com.bootcamp.be_java_hisp_w25_g02.entity.User;
+import com.bootcamp.be_java_hisp_w25_g02.exception.BadRequestException;
+import com.bootcamp.be_java_hisp_w25_g02.repository.IUserRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.*;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
 @ExtendWith(MockitoExtension.class)
 class UserServiceImplTest {
 
     @Mock
-    IUserRepository userRepository;
+    IUserRepository iUserRepository;
     @InjectMocks
-    UserServiceImpl userService;
+    UserServiceImpl userServiceImpl;
+
+    @Test
+    @DisplayName("T0004 - When calling getFollowersList(), without an 'order' param, the list is returned without any order.")
+    public void getFollowersListTestNoOrderParam(){
+        // Arr
+        String order = null;
+
+        List<Integer> list1 = List.of(1, 2, 3, 4);
+        List<Integer> list2 = List.of(6, 7, 8, 9, 10);
+        User user1 = new User(5, "Matias Del Salvador", true, list1, list2);
+
+        List<Integer> list3 = List.of(1, 2, 3, 4);
+        List<Integer> list4 = List.of(5, 7, 8, 9, 10);
+        User user2 = new User(6, "Romina Fuentes", true, list3, list4);
+
+        List<Integer> list5 = List.of(1, 2, 3, 4);
+        List<Integer> list6 = List.of(5, 6, 8, 9, 10);
+        User user3 = new User(7, "Abel Gomez", true, list5, list6);
+
+        List<Integer> list8 = List.of(5, 6, 7);
+        List<Integer> list9 = List.of(5, 6, 7);
+        User user4 = new User(12, "Jorge Alba", true, list8, list9);
+
+        // List<UserDTO> userOptional = List.of(user1, user2, user3);
+
+        // Act
+
+        when(iUserRepository.findById(anyInt())).thenReturn(Optional.of(user4));
+        when(iUserRepository.findById(anyInt())).thenReturn(Optional.of(user1));
+        when(iUserRepository.findById(anyInt())).thenReturn(Optional.of(user2));
+        when(iUserRepository.findById(anyInt())).thenReturn(Optional.of(user3));
+
+
+        // Assert
+        // Assertions.assertEquals();
+
+    }
+
+    @Test
+    @DisplayName("T0003 - When calling getFollowersList(), an exception is thrown if 'order' has an incorrect value")
+    public void getFollowersListTestIncorrectOrderParam(){
+        // Arr
+
+        String incorrectOrderString = "algoIncorrecto";
+        /*
+        List<Integer> list1 = List.of(1, 2, 3, 4);
+        List<Integer> list2 = List.of(6, 7, 8, 9, 10);
+
+        User user = new User(5, "Matias Del Salvador", true, list1, list2);
+
+        Optional<User> userOptional = Optional.of(user);
+        */
+
+        // Act and Assert
+
+        Assertions.assertThrows(BadRequestException.class,
+                ()-> userServiceImpl.getFollowersList(1, incorrectOrderString));
+    }
+
 }

--- a/src/test/java/com/bootcamp/be_java_hisp_w25_g02/service/UserServiceImplTest.java
+++ b/src/test/java/com/bootcamp/be_java_hisp_w25_g02/service/UserServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.bootcamp.be_java_hisp_w25_g02.service;
 
+import com.bootcamp.be_java_hisp_w25_g02.dto.response.FollowerListDTO;
 import com.bootcamp.be_java_hisp_w25_g02.repository.IUserRepository;
 import com.bootcamp.be_java_hisp_w25_g02.dto.response.UserDTO;
 import com.bootcamp.be_java_hisp_w25_g02.entity.User;
@@ -37,54 +38,132 @@ class UserServiceImplTest {
         // Arr
         String order = null;
 
-        List<Integer> list1 = List.of(1, 2, 3, 4);
-        List<Integer> list2 = List.of(6, 7, 8, 9, 10);
+        List<Integer> list1 = List.of(1, 2, 3);
+        List<Integer> list2 = List.of(6, 7, 10);
         User user1 = new User(5, "Matias Del Salvador", true, list1, list2);
 
-        List<Integer> list3 = List.of(1, 2, 3, 4);
-        List<Integer> list4 = List.of(5, 7, 8, 9, 10);
+        List<Integer> list3 = List.of(1, 2, 3);
+        List<Integer> list4 = List.of(5, 7, 10);
         User user2 = new User(6, "Romina Fuentes", true, list3, list4);
 
-        List<Integer> list5 = List.of(1, 2, 3, 4);
-        List<Integer> list6 = List.of(5, 6, 8, 9, 10);
+        List<Integer> list5 = List.of(1, 2, 3);
+        List<Integer> list6 = List.of(5, 6, 10);
         User user3 = new User(7, "Abel Gomez", true, list5, list6);
 
         List<Integer> list8 = List.of(5, 6, 7);
         List<Integer> list9 = List.of(5, 6, 7);
         User user4 = new User(12, "Jorge Alba", true, list8, list9);
 
-        // List<UserDTO> userOptional = List.of(user1, user2, user3);
+        List<UserDTO> listOfUserDTOs = List.of(
+                new UserDTO(user1.getUserId(), user1.getUserName()),
+                new UserDTO(user2.getUserId(), user2.getUserName()),
+                new UserDTO(user3.getUserId(), user3.getUserName())
+        );
 
+        FollowerListDTO myAnsDTO = new FollowerListDTO(user4.getUserId(), user4.getUserName(), listOfUserDTOs);
         // Act
 
-        when(iUserRepository.findById(anyInt())).thenReturn(Optional.of(user4));
-        when(iUserRepository.findById(anyInt())).thenReturn(Optional.of(user1));
-        when(iUserRepository.findById(anyInt())).thenReturn(Optional.of(user2));
-        when(iUserRepository.findById(anyInt())).thenReturn(Optional.of(user3));
-
-
+        when(iUserRepository.findById(anyInt())).thenReturn(
+                Optional.of(user4),
+                Optional.of(user1),
+                Optional.of(user2),
+                Optional.of(user3)
+        );
         // Assert
-        // Assertions.assertEquals();
+        Assertions.assertEquals(myAnsDTO, userServiceImpl.getFollowersList(12, null));
 
+    }
+
+    @Test
+    @DisplayName("T0004 - When calling getFollowersList(), with 'order' param being 'name_asc' , the list is returned in order ascending by name.")
+    public void getFollowersListTestOrderAsc(){
+        // Arr
+        String order = null;
+
+        List<Integer> list1 = List.of(1, 2, 3);
+        List<Integer> list2 = List.of(6, 7, 10);
+        User user1 = new User(5, "Matias Del Salvador", true, list1, list2);
+
+        List<Integer> list3 = List.of(1, 2, 3);
+        List<Integer> list4 = List.of(5, 7, 10);
+        User user2 = new User(6, "Romina Fuentes", true, list3, list4);
+
+        List<Integer> list5 = List.of(1, 2, 3);
+        List<Integer> list6 = List.of(5, 6, 10);
+        User user3 = new User(7, "Abel Gomez", true, list5, list6);
+
+        List<Integer> list8 = List.of(5, 6, 7);
+        List<Integer> list9 = List.of(5, 6, 7);
+        User user4 = new User(12, "Jorge Alba", true, list8, list9);
+
+        List<UserDTO> listOfUserDTOs = List.of(
+                new UserDTO(user3.getUserId(), user3.getUserName()),
+                new UserDTO(user1.getUserId(), user1.getUserName()),
+                new UserDTO(user2.getUserId(), user2.getUserName())
+        );
+
+        FollowerListDTO myAnsDTO = new FollowerListDTO(user4.getUserId(), user4.getUserName(), listOfUserDTOs);
+        // Act
+
+        when(iUserRepository.findById(anyInt())).thenReturn(
+                Optional.of(user4),
+                Optional.of(user3),
+                Optional.of(user1),
+                Optional.of(user2)
+        );
+        // Assert
+        Assertions.assertEquals(myAnsDTO, userServiceImpl.getFollowersList(12, null));
+    }
+
+    @Test
+    @DisplayName("T0004 - When calling getFollowersList(), with 'order' param being 'name_desc' , the list is returned in order descending by name.")
+    public void getFollowersListTestOrderDesc(){
+
+        // Arr
+        String order = null;
+
+        List<Integer> list1 = List.of(1, 2, 3);
+        List<Integer> list2 = List.of(6, 7, 10);
+        User user1 = new User(5, "Matias Del Salvador", true, list1, list2);
+
+        List<Integer> list3 = List.of(1, 2, 3);
+        List<Integer> list4 = List.of(5, 7, 10);
+        User user2 = new User(6, "Romina Fuentes", true, list3, list4);
+
+        List<Integer> list5 = List.of(1, 2, 3);
+        List<Integer> list6 = List.of(5, 6, 10);
+        User user3 = new User(7, "Abel Gomez", true, list5, list6);
+
+        List<Integer> list8 = List.of(5, 6, 7);
+        List<Integer> list9 = List.of(5, 6, 7);
+        User user4 = new User(12, "Jorge Alba", true, list8, list9);
+
+        List<UserDTO> listOfUserDTOs = List.of(
+                new UserDTO(user2.getUserId(), user2.getUserName()),
+                new UserDTO(user1.getUserId(), user1.getUserName()),
+                new UserDTO(user3.getUserId(), user3.getUserName())
+        );
+
+        FollowerListDTO myAnsDTO = new FollowerListDTO(user4.getUserId(), user4.getUserName(), listOfUserDTOs);
+        // Act
+
+        when(iUserRepository.findById(anyInt())).thenReturn(
+                Optional.of(user4),
+                Optional.of(user2),
+                Optional.of(user1),
+                Optional.of(user3)
+        );
+        // Assert
+        Assertions.assertEquals(myAnsDTO, userServiceImpl.getFollowersList(12, null));
     }
 
     @Test
     @DisplayName("T0003 - When calling getFollowersList(), an exception is thrown if 'order' has an incorrect value")
     public void getFollowersListTestIncorrectOrderParam(){
         // Arr
-
         String incorrectOrderString = "algoIncorrecto";
-        /*
-        List<Integer> list1 = List.of(1, 2, 3, 4);
-        List<Integer> list2 = List.of(6, 7, 8, 9, 10);
-
-        User user = new User(5, "Matias Del Salvador", true, list1, list2);
-
-        Optional<User> userOptional = Optional.of(user);
-        */
 
         // Act and Assert
-
         Assertions.assertThrows(BadRequestException.class,
                 ()-> userServiceImpl.getFollowersList(1, incorrectOrderString));
     }


### PR DESCRIPTION
- Method `UserServiceImpl.getFollowersList()` was refactorized, so that it validates whether the "order" parameter is correct BEFORE requesting results to the Database (saves time).
4 test cases were added:
- Corresponding to T0003, we test that an exception is thrown if the `order` param value is other than `null`, `"name_asc" `or `"name_desc"`
- Corresponding to T0004, we test that the returned list of the method is in correct order when the `order` param value is `null` (no sorting is made),
- Corresponding to T0004, we test that the returned list of the method is in correct order when the `order` param value is `name_asc`
- Corresponding to T0004, we test that the returned list of the method is in correct order when the `order` param value is `name_desc`